### PR TITLE
Update CoordinatesCache.php

### DIFF
--- a/Classes/Cache/CoordinatesCache.php
+++ b/Classes/Cache/CoordinatesCache.php
@@ -94,9 +94,9 @@ class CoordinatesCache
         );
 
         $hash = $this->getHashForAddressWithFields($address, $fields);
-        if (count($fields) <= 3) {
+        if (count($fields) == 2 || count($fields) == 3) {
             $this->setValueInCacheTable($hash, $coordinate);
-        } else {
+        } elseif (count($fields) > 3) {
             $this->setValueInSession($hash, $coordinate);
         }
     }


### PR DESCRIPTION
prevent saving cache entry if we have only one field (e.g. country only)