### PR TITLE
Add second Google Console Key for Geocoding API.

### DIFF
--- a/Classes/Service/Provider/GoogleMapsProvider.php
+++ b/Classes/Service/Provider/GoogleMapsProvider.php
@@ -34,8 +34,13 @@ class GoogleMapsProvider implements EncodeProviderInterface
             return [false, new \stdClass()];
         }
 
+        $apiConsoleKeyGeocoding = $settings['apiConsoleKeyGeocoding'];
+        if (empty($apiConsoleKeyGeocoding)) {
+            $apiConsoleKeyGeocoding = $settings['apiConsoleKey'];
+        }
+
         $apiUrl = $settings['geocodeUrl'] .
-            (!empty($settings['apiConsoleKeyGeocoding']) ? '&key=' . $settings['apiConsoleKeyGeocoding'] : '') .
+            (!empty($apiConsoleKeyGeocoding) ? '&key=' . $apiConsoleKeyGeocoding : '') .
             '&address=' . implode('+', $parameter) .
             (!empty($components) ? '&components=' . implode('|', $components) : '');
         if (TYPO3_MODE == 'FE' && isset($this->getTypoScriptFrontendController()->lang)) {

--- a/Classes/Service/Provider/GoogleMapsProvider.php
+++ b/Classes/Service/Provider/GoogleMapsProvider.php
@@ -35,7 +35,7 @@ class GoogleMapsProvider implements EncodeProviderInterface
         }
 
         $apiUrl = $settings['geocodeUrl'] .
-            (!empty($settings['apiConsoleKey']) ? '&key=' . $settings['apiConsoleKey'] : '') .
+            (!empty($settings['apiConsoleKeyGeocoding']) ? '&key=' . $settings['apiConsoleKeyGeocoding'] : '') .
             '&address=' . implode('+', $parameter) .
             (!empty($components) ? '&components=' . implode('|', $components) : '');
         if (TYPO3_MODE == 'FE' && isset($this->getTypoScriptFrontendController()->lang)) {

--- a/Classes/Service/Provider/MapQuestProvider.php
+++ b/Classes/Service/Provider/MapQuestProvider.php
@@ -19,8 +19,13 @@ class MapQuestProvider implements EncodeProviderInterface
 {
     public function encodeAddress(array $parameter, array $settings): array
     {
+        $apiConsoleKeyGeocoding = $settings['apiConsoleKeyGeocoding'];
+        if (empty($apiConsoleKeyGeocoding)) {
+            $apiConsoleKeyGeocoding = $settings['apiConsoleKey'];
+        }
+
         $apiUrl = $settings['geocodeUrl'] .
-            (!empty($settings['apiConsoleKeyGeocoding']) ? '&key=' . $settings['apiConsoleKeyGeocoding'] : '') .
+            (!empty($apiConsoleKeyGeocoding) ? '&key=' . $apiConsoleKeyGeocoding : '') .
             '&location=' . implode(',', $parameter);
 
         $addressData = json_decode(utf8_encode(

--- a/Classes/Service/Provider/MapQuestProvider.php
+++ b/Classes/Service/Provider/MapQuestProvider.php
@@ -20,7 +20,7 @@ class MapQuestProvider implements EncodeProviderInterface
     public function encodeAddress(array $parameter, array $settings): array
     {
         $apiUrl = $settings['geocodeUrl'] .
-            (!empty($settings['apiConsoleKey']) ? '&key=' . $settings['apiConsoleKey'] : '') .
+            (!empty($settings['apiConsoleKeyGeocoding']) ? '&key=' . $settings['apiConsoleKeyGeocoding'] : '') .
             '&location=' . implode(',', $parameter);
 
         $addressData = json_decode(utf8_encode(

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -9,7 +9,10 @@ plugin.tx_storefinder.settings {
   # needed for google or mapQuest accounts
   # starting with June 2018 google map only provides premium access.
   # https://mapsplatform.googleblog.com/2018/05/introducing-google-maps-platform.html
+  # Used for https://developers.google.com/maps/documentation/geocoding/start
   apiConsoleKey =
+  # used for https://developers.google.com/maps/documentation/javascript/tutorial
+  apiConsoleKeyGeocoding =
 
   categories =
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -42,6 +42,7 @@ plugin.tx_storefinder.settings
   geocodeUrl_                                           :ref:`data-type-string`                           yes                   no         service url
   useConsoleKeyForGeocoding_                            :ref:`data-type-boolean`                          yes        no         no         0
   apiConsoleKey_                                        :ref:`data-type-string`                           yes        no         no         -
+  apiConsoleKeyGeocoding_                               :ref:`data-type-string`                           yes        no         no         -
   distanceUnit_                                         :ref:`data-type-string`                           yes                   no         miles
   `mapConfiguration.language <mc-language_>`_           :ref:`data-type-string`                           yes                   no         en
   `mapConfiguration.allowSensors <mc-allowSensors_>`_   :ref:`data-type-boolean`                          yes                   no         1
@@ -292,12 +293,26 @@ plugin.tx_storefinder.persistence
          string
 
    Description
-         If you want to use static maps in the map output or premium geo coding you need
-         to register an geo code api key at google.
-         https://developers.google.com/maps/documentation/javascript/get-api-key
+         Used for geocoding and reverse geocoding of addresses via Google Maps Geocoding API. Must have access for Google Maps Geocoding API and can only be restricted by ip addresses.
 
    Default
 
+
+.. _apiConsoleKeyGeocoding:
+.. ### BEGIN~OF~TABLE ###
+
+.. container:: table-row
+
+   Property
+         apiConsoleKeyGeocoding
+
+   Data type
+         string
+
+   Description
+         Used for output map via Google Maps JavaScript API. Must have access for Google Maps JavaScript API and can only be restricted by domains.
+
+   Default
 
 
 .. _distanceUnit:

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -4,7 +4,10 @@
 		<header/>
 		<body>
 			<trans-unit id="apiConsoleKey">
-				<source>Api Console Key: (Google Maps API [https://developers.google.com/maps/documentation/javascript/get-api-key])</source>
+				<source>Api Console Key for Maps: (Google Maps JavaScript API [https://developers.google.com/maps/documentation/javascript/get-api-key])</source>
+			</trans-unit>
+			<trans-unit id="apiConsoleKeyGeocoding">
+				<source>Api Console Key for Geocoding: (Google Maps Geocoding API [https://developers.google.com/maps/documentation/geocoding/get-api-key])</source>
 			</trans-unit>
 			<trans-unit id="apiProvider">
 				<source>Name of API to use (mapQuest, googleMaps or fully qualified classname)</source>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,4 +1,4 @@
-# cat=basic/enable/100; type=input; label=LLL:EXT:store_finder/Resources/Private/Language/locallang_be.xlf:apiKeyClient
+# cat=basic/enable/100; type=input; label=LLL:EXT:store_finder/Resources/Private/Language/locallang_be.xlf:apiConsoleKey
 apiConsoleKey =
 
 # cat=basic/enable/100; type=input; label=LLL:EXT:store_finder/Resources/Private/Language/locallang_be.xlf:apiConsoleKeyGeocoding

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,5 +1,8 @@
-# cat=basic/enable/100; type=input; label=LLL:EXT:store_finder/Resources/Private/Language/locallang_be.xlf:apiConsoleKey
+# cat=basic/enable/100; type=input; label=LLL:EXT:store_finder/Resources/Private/Language/locallang_be.xlf:apiKeyClient
 apiConsoleKey =
+
+# cat=basic/enable/100; type=input; label=LLL:EXT:store_finder/Resources/Private/Language/locallang_be.xlf:apiConsoleKeyGeocoding
+apiConsoleKeyGeocoding =
 
 # cat=basic/enable/100; type=input; label=LLL:EXT:store_finder/Resources/Private/Language/locallang_be.xlf:apiProvider
 apiProvider = googleMaps


### PR DESCRIPTION
When the Google Maps API Key will be restricted by domains, it can't be used anymore for Geocoding API, because Geocoding API can be only restricted by ip addresses. Also the Geocoding API Key is used server-side, so there is no Domain used as referrer. If you switch the whole API Key to ip address restriction, the maps on frontend won't be loaded anymore because of ip address of client will be used.

Best practice is using a second API Key just got Geocoding API. The first one won't be changed and can be used for JavaScript API.

https://developers.google.com/maps/faq#browser-keys-blocked-error

For this case I have added a second API Key field in settings, which will be used for geocoding.