### PR TITLE
Update LocationRepository.php

### DIFF
--- a/Classes/Domain/Repository/LocationRepository.php
+++ b/Classes/Domain/Repository/LocationRepository.php
@@ -83,7 +83,8 @@ class LocationRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
         $query = $this->createQuery();
         $query->getQuerySettings()
             ->setIgnoreEnableFields(true)
-            ->setRespectStoragePage(false);
+            ->setRespectStoragePage(false)
+            ->setRespectSyslanguage(false);
 
         /** @var Location $location */
         $location = $query


### PR DESCRIPTION
Saving an element which is translated, results in an error cause the system respects the syslangaugeUid and can´t find that Uid in that language.