### PR TITLE
Update CoordinatesCache.php

### DIFF
--- a/Classes/Cache/CoordinatesCache.php
+++ b/Classes/Cache/CoordinatesCache.php
@@ -44,7 +44,7 @@ class CoordinatesCache
         $cacheFrontend = $cacheManager->getCache('store_finder_coordinate');
 
         /** @var FrontendUserAuthentication $frontendUser */
-        $frontendUser = ($GLOBALS['TSFE']) ? $GLOBALS['TSFE']->fe_user : null;
+        $frontendUser = ($GLOBALS['TSFE'] ?? null) ? $GLOBALS['TSFE']->fe_user : null;
 
         /** @var self $instance */
         $instance = GeneralUtility::makeInstance(self::class, $cacheFrontend, $frontendUser);


### PR DESCRIPTION
fix PHP Warning: Undefined array key "TSFE" in PHP 8.0 / LTS 11 when saving a record in BE