### PR TITLE
Include comma into the regex pattern of the preg_replace to prevent it from being deleted

### DIFF
--- a/Classes/Domain/Repository/LocationRepository.php
+++ b/Classes/Domain/Repository/LocationRepository.php
@@ -395,7 +395,7 @@ class LocationRepository extends Repository
 
     protected function addFulltextSearchQueryParts(Constraint $constraint, QueryBuilder $queryBuilder): QueryBuilder
     {
-        $search = preg_replace('/[^a-zA-Z0-9äöüÄÖÜß]+/', '', $constraint->getSearch());
+        $search = preg_replace('/[^a-zA-Z0-9äöüÄÖÜß,]+/', '', $constraint->getSearch());
         if (
             $search
             && isset($this->settings['fulltextSearchFields'])


### PR DESCRIPTION
The preg_replace removes all commas from the search parameters thus the GeneralUtility:trimExplode() later in the function cannot properly separated the search keywords.