### PR TITLE
[MINOR] // Change the foreign_table_where statement to fix Database error in backend

### DIFF
--- a/Configuration/TCA/tx_storefinder_domain_model_attribute.php
+++ b/Configuration/TCA/tx_storefinder_domain_model_attribute.php
@@ -46,7 +46,7 @@ return [
                 // no sys_language_uid = -1 allowed explicitly!
                 'foreign_table_where' =>
                     'AND tx_storefinder_domain_model_attribute.pid = ###CURRENT_PID###
-                     AND tx_storefinder_domain_model_attribute.sys_language_uid IN = 0',
+                     AND tx_storefinder_domain_model_attribute.sys_language_uid = 0',
                 'default' => 0
             ]
         ],


### PR DESCRIPTION
The foreign_table_where statement in tx_storefinder_domain_model_attribute should either be '... sys_language_uid = 0' if comparing to single integer, or '...sys_language_uid IN (0, ...)' if compared to multiple values.
A database error is displayed when editing records as both comparison operators collide here.