### PR TITLE
Allow PhpSpreadsheet v2,v5 for compatibility with Powermail v13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
 		"symfony/console": "^7.1",
 		"geocoder-php/google-maps-provider": "^4.7.1",
 		"php-http/discovery": "^1.16",
-		"phpoffice/phpspreadsheet": "^2.2.0"
+		"phpoffice/phpspreadsheet": "^2.2.0 || ^5.2.0"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.64.0",


### PR DESCRIPTION
This update widens the allowed PhpSpreadsheet versions (v2, v5) to improve compatibility with other TYPO3 extensions.
Powermail v13, for example, depends on PhpSpreadsheet v5.